### PR TITLE
Fix iOS viewport height for globe

### DIFF
--- a/src/hooks/use-hdr-setup.tsx
+++ b/src/hooks/use-hdr-setup.tsx
@@ -31,10 +31,20 @@ export function useHDRSetup() {
     // Stable full-screen CSS var for iOS 26 fixed overlays
     function setOuterHeightVar() {
       try {
-        const outerH = Math.max(window.outerHeight || 0, window.innerHeight || 0);
-        const px = outerH + 'px';
-        document.documentElement.style.setProperty('--outer-h', px);
-        document.documentElement.style.setProperty('--screen-h', px);
+        const visualViewportHeight = window.visualViewport?.height ?? 0;
+        const innerHeight = window.innerHeight || 0;
+        const viewportHeight = Math.max(visualViewportHeight, innerHeight);
+
+        if (viewportHeight > 0) {
+          const viewportPx = `${viewportHeight}px`;
+          document.documentElement.style.setProperty('--screen-h', viewportPx);
+        }
+
+        const outerHeight = window.outerHeight || viewportHeight;
+        if (outerHeight > 0) {
+          const outerPx = `${outerHeight}px`;
+          document.documentElement.style.setProperty('--outer-h', outerPx);
+        }
       } catch {}
     }
     setOuterHeightVar();


### PR DESCRIPTION
## Summary
- derive the globe viewport height from the visual viewport (or inner height) instead of relying on outerHeight
- keep the CSS custom properties in sync so the WebGL canvas fills the screen on iOS

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0e0784f608326bf3d79058b6850e0