### PR TITLE
Adjust globe rendering for iOS safe area

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -242,6 +242,8 @@ body {
   height: 100dvh; /* Dynamic viewport height */
   height: var(--screen-h, 100dvh); /* Visual viewport synced from JS */
   min-height: -webkit-fill-available; /* iOS Safari */
+  box-sizing: border-box;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   overflow: hidden;
 
   & > div {
@@ -255,6 +257,10 @@ body {
     animation: fadeIn 5s ease-in-out;
     background-color: rgb(0, 0, 0);
   }
+}
+
+.globe-container footer {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 /* Ensure the WebGL canvas fills the container exactly */

--- a/src/lib/globes/globe.tsx
+++ b/src/lib/globes/globe.tsx
@@ -43,29 +43,6 @@ function randomInRange(min: number, max: number): number {
   return Math.random() * (max - min) + min;
 }
 
-function readCssPxVariable(varName: string): number | undefined {
-  if (typeof window === 'undefined') {
-    return undefined;
-  }
-
-  const raw = getComputedStyle(document.documentElement).getPropertyValue(varName);
-  if (!raw) {
-    return undefined;
-  }
-
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-
-  const parsed = Number.parseFloat(trimmed);
-  if (!Number.isFinite(parsed)) {
-    return undefined;
-  }
-
-  return Math.ceil(parsed);
-}
-
 function useLandPolygons() {
   const [landPolygons, setLandPolygons] = useState([]);
   useEffect(() => {
@@ -532,21 +509,6 @@ function Globe({ albums }: { albums: Array<Album> }) {
     };
   }, []);
 
-  // Prefer stable height on iOS using --outer-h when available
-  const stableOuterHeight = (() => {
-    const screenHeight = readCssPxVariable('--screen-h');
-    if (screenHeight && screenHeight > 0) {
-      return screenHeight;
-    }
-
-    const outerHeight = readCssPxVariable('--outer-h');
-    if (outerHeight && outerHeight > 0) {
-      return outerHeight;
-    }
-
-    return undefined;
-  })();
-
   return (
     <section
       ref={containerRef as any}
@@ -567,11 +529,9 @@ function Globe({ albums }: { albums: Array<Album> }) {
         width={(containerWidth && containerWidth > 0)
           ? Math.ceil(containerWidth)
           : width}
-        height={(stableOuterHeight && stableOuterHeight > 0)
-          ? stableOuterHeight // exact stable height to avoid overshoot
-          : ((containerHeight && containerHeight > 0)
-            ? Math.ceil(containerHeight)
-            : (height && height > 0 ? Math.ceil(height) : undefined))}
+        height={(containerHeight && containerHeight > 0)
+          ? Math.ceil(containerHeight)
+          : (height && height > 0 ? Math.ceil(height) : undefined)}
         rendererConfig={{ 
           antialias: true, // Better performance
           powerPreference: "high-performance"


### PR DESCRIPTION
## Summary
- ensure the globe canvas uses the measured container height so it no longer renders underneath Safari's bottom chrome
- add safe-area padding to the globe container and footer to keep content above iOS Safari's bottom bar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0f34bc48c8326beafc56af159abb3