### PR TITLE
Fix globe viewport coverage on iOS Safari

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,8 @@
 html,
 body {
   height: 100%;
+  min-height: 100%;
+  min-height: -webkit-fill-available;
   margin: 0;
 }
 
@@ -68,6 +70,7 @@ body:has(.app-fullscreen) {
     body:has(.globe-container) .globe-container {
       /* Stable full physical screen height for Safari */
       min-height: -webkit-fill-available !important;
+      height: -webkit-fill-available !important;
       height: 100vh !important;
       height: 100svh !important;
       height: 100dvh !important;
@@ -99,6 +102,7 @@ body:has(.app-fullscreen) {
       min-height: 100svh;
       min-height: 100dvh;
       min-height: -webkit-fill-available;
+      height: -webkit-fill-available;
       /* Avoid pushing canvas down; manage safe-area within content */
       padding-top: 0 !important;
       padding-bottom: 0 !important;
@@ -241,9 +245,8 @@ body {
   height: 100svh; /* Small viewport (with UI visible) */
   height: 100dvh; /* Dynamic viewport height */
   height: var(--screen-h, 100dvh); /* Visual viewport synced from JS */
+  height: -webkit-fill-available; /* iOS Safari fill behind UI */
   min-height: -webkit-fill-available; /* iOS Safari */
-  box-sizing: border-box;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
   overflow: hidden;
 
   & > div {
@@ -257,10 +260,6 @@ body {
     animation: fadeIn 5s ease-in-out;
     background-color: rgb(0, 0, 0);
   }
-}
-
-.globe-container footer {
-  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 /* Ensure the WebGL canvas fills the container exactly */


### PR DESCRIPTION
## Summary
- ensure the document and globe container explicitly use `-webkit-fill-available` so the canvas can render under Safari UI chrome
- remove extra safe-area padding so the globe content now extends behind the address and bottom bars

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0f5621e6483268b87c68fa59a4902