### PR TITLE
Fix iOS Safari viewport height for globe page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,7 +74,7 @@ body:has(.app-fullscreen) {
       height: 100vh !important;
       height: 100svh !important;
       height: 100dvh !important;
-      height: var(--screen-h, 100dvh) !important;
+      height: var(--screen-h, 100lvh) !important;
       width: 100% !important;
       position: relative !important;
       top: 0 !important;
@@ -95,22 +95,25 @@ body:has(.app-fullscreen) {
       z-index: 20 !important;
     }
     
-    /* Fix for iOS address bar hiding/showing - ONLY for globe page */
-    body:has(.globe-container) {
-      /* Prefer stable viewport height and fill available */
-      min-height: 100vh;
-      min-height: 100svh;
-      min-height: 100dvh;
-      min-height: -webkit-fill-available;
-      height: -webkit-fill-available;
-      /* Avoid pushing canvas down; manage safe-area within content */
-      padding-top: 0 !important;
-      padding-bottom: 0 !important;
-      /* Disable scrolling on iOS Safari */
-      overflow: hidden !important;
-      position: relative !important;
-      width: 100% !important;
-    }
+      /* Fix for iOS address bar hiding/showing - ONLY for globe page */
+      body:has(.globe-container) {
+        /* Prefer stable viewport height and fill available */
+        min-height: 100vh;
+        min-height: 100svh;
+        min-height: 100lvh;
+        min-height: 100dvh;
+        min-height: -webkit-fill-available;
+        min-height: var(--screen-h, 100lvh);
+        height: -webkit-fill-available;
+        height: var(--screen-h, 100lvh);
+        /* Avoid pushing canvas down; manage safe-area within content */
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        /* Disable scrolling on iOS Safari */
+        overflow: hidden !important;
+        position: relative !important;
+        width: 100% !important;
+      }
     
     html:has(.globe-container) {
       height: -webkit-fill-available;
@@ -243,9 +246,15 @@ body {
   flex-direction: column;
   height: 100vh; /* Base fallback */
   height: 100svh; /* Small viewport (with UI visible) */
+  height: 100lvh; /* Large viewport (behind iOS Safari UI) */
   height: 100dvh; /* Dynamic viewport height */
-  height: var(--screen-h, 100dvh); /* Visual viewport synced from JS */
+  height: var(--screen-h, 100lvh); /* Visual viewport synced from JS */
   height: -webkit-fill-available; /* iOS Safari fill behind UI */
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100lvh;
+  min-height: 100dvh;
+  min-height: var(--screen-h, 100lvh);
   min-height: -webkit-fill-available; /* iOS Safari */
   overflow: hidden;
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,14 +55,35 @@ export default function RootLayout({
         <meta name="x5-page-mode" content="app" />
         <Script id="set-screen-height" strategy="beforeInteractive">
           {`
-            function setScreenH() {
-              const h = window.outerHeight || window.innerHeight;
-              document.documentElement.style.setProperty('--screen-h', h + 'px');
+            function setScreenMetrics() {
+              const docEl = document.documentElement;
+              const visualViewportHeight = window.visualViewport?.height ?? 0;
+              const innerHeight = window.innerHeight ?? 0;
+              const outerHeight = window.outerHeight ?? 0;
+              const clientHeight = docEl?.clientHeight ?? 0;
+              const screenHeight = window.screen?.height ?? 0;
+              const viewportHeight = Math.max(
+                visualViewportHeight,
+                innerHeight,
+                outerHeight,
+                clientHeight,
+                screenHeight
+              );
+
+              if (viewportHeight > 0) {
+                docEl.style.setProperty('--screen-h', viewportHeight + 'px');
+              }
+
+              if (screenHeight > 0) {
+                docEl.style.setProperty('--outer-h', screenHeight + 'px');
+              } else if (outerHeight > 0) {
+                docEl.style.setProperty('--outer-h', outerHeight + 'px');
+              }
             }
-            setScreenH();
-            addEventListener('orientationchange', setScreenH, { passive: true });
-            addEventListener('pageshow', setScreenH, { passive: true });
-            addEventListener('resize', setScreenH, { passive: true });
+            setScreenMetrics();
+            addEventListener('orientationchange', setScreenMetrics, { passive: true });
+            addEventListener('pageshow', setScreenMetrics, { passive: true });
+            addEventListener('resize', setScreenMetrics, { passive: true });
           `}
         </Script>
       </head>

--- a/src/hooks/use-hdr-setup.tsx
+++ b/src/hooks/use-hdr-setup.tsx
@@ -33,17 +33,25 @@ export function useHDRSetup() {
       try {
         const visualViewportHeight = window.visualViewport?.height ?? 0;
         const innerHeight = window.innerHeight ?? 0;
+        const outerHeight = window.outerHeight ?? 0;
         const clientHeight = document.documentElement?.clientHeight ?? 0;
-        const viewportHeight = Math.max(visualViewportHeight, innerHeight, clientHeight);
+        const screenHeight = window.screen?.height ?? 0;
+        const viewportHeight = Math.max(
+          visualViewportHeight,
+          innerHeight,
+          outerHeight,
+          clientHeight,
+          screenHeight
+        );
 
         if (viewportHeight > 0) {
           const viewportPx = `${viewportHeight}px`;
           document.documentElement.style.setProperty('--screen-h', viewportPx);
         }
 
-        const outerHeight = window.outerHeight ?? viewportHeight;
-        if (outerHeight > 0) {
-          const outerPx = `${outerHeight}px`;
+        const outerViewportHeight = Math.max(screenHeight, outerHeight, viewportHeight);
+        if (outerViewportHeight > 0) {
+          const outerPx = `${outerViewportHeight}px`;
           document.documentElement.style.setProperty('--outer-h', outerPx);
         }
       } catch {}


### PR DESCRIPTION
## Summary
- compute screen metrics from the largest available viewport values before hydration to stabilize the globe page on iOS Safari
- sync the HDR setup hook to use the same large-viewport fallbacks for `--screen-h`/`--outer-h`
- extend globe CSS overrides to prefer `lvh` fallbacks so the canvas renders behind the Safari address bar

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d0f74365208326901ec6f546f55f24