### PR TITLE
Remove iOS typewriter album list moving animation effect

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1181,22 +1181,6 @@ body:has(.globe-container) .typewriter {
   --caret: currentColor;
 }
 
-/* iOS Safari: Stabilize typewriter item during slide animation */
-@supports (-webkit-touch-callout: none) {
-  @media (max-device-width: 1024px) and (orientation: portrait) {
-    /* The li containing typewriter should NOT transform - it stays in place */
-    body:has(.globe-container) .album-list.album-list-sliding li:has(.typewriter) {
-      -webkit-transform: translateX(0) !important;
-      transform: translateX(0) !important;
-    }
-    body:has(.globe-container) .album-list.album-list-sliding .typewriter {
-      /* Prevent width changes from causing layout shifts */
-      display: inline-block !important;
-      min-width: 100% !important;
-      text-align: left !important;
-    }
-  }
-}
 body:has(.globe-container) .typewriter::after {
   content: none;
   border-right: 0;


### PR DESCRIPTION
Drop the iOS Safari-specific CSS block that stabilized the typewriter
item during the album-list slide animation. The typewriter li no longer
gets a counter-translate, and width/alignment overrides on the
typewriter element are removed.