### PR TITLE
Disable zoom-in on mobile when selecting a location

### DIFF
--- a/src/lib/globes/globe.tsx
+++ b/src/lib/globes/globe.tsx
@@ -241,8 +241,10 @@ function useAlbumInteraction(
 
     const id = setTimeout(() => {
       if (type === types.LOCATION) {
-        // Slightly more zoomed out on mobile devices, 30% more zoom when selected
-        const altitudeOnFocus = isMobileDevice() ? 0.84 : 0.7;
+        // Slightly more zoomed out on mobile devices, 30% more zoom when selected.
+        // On mobile, the zoom-in is disabled: keep the default mobile altitude so the
+        // camera still pans to the location without zooming in.
+        const altitudeOnFocus = isMobileDevice() ? /* zoom-in disabled: 0.84 */ 2.8 : 0.7;
         globeEl.current?.pointOfView(
           {
             lat,


### PR DESCRIPTION
Keep panning the camera to the selected location on mobile, but use the
default mobile altitude instead of zooming in.