### PR TITLE
Remove globe city tooltip; blue-gradient active title; longer intro fade

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -397,7 +397,7 @@ body {
   /* Arrival: sharpen + settle while the camera flies in from deep space.
      No fill mode: the filter/transform must fully revert once it finishes
      so the WebGL canvas isn't left compositing through an identity filter. */
-  animation: globeEnter 2.6s cubic-bezier(0.23, 1, 0.32, 1);
+  animation: globeEnter 4.6s cubic-bezier(0.23, 1, 0.32, 1);
   background-color: #1a1a1f; /* Blends with globe atmosphere */
 }
 
@@ -594,89 +594,6 @@ body:has(.album-page) {
   pointer-events: none;
 }
 
-/* ========================================
-   Globe city tooltip (CSS2D layer)
-   ======================================== */
-
-/* Root is renderer-controlled (position/transform set by CSS2DRenderer);
-   it stays a zero-size anchor at the selected point */
-.globe-tooltip {
-  pointer-events: none;
-}
-
-/* The visible bubble floats above the anchor and pops in with an overshoot */
-.globe-tooltip-bubble {
-  position: absolute;
-  left: 0;
-  bottom: 16px;
-  white-space: nowrap;
-  padding: 0.32rem 0.75rem;
-  border-radius: 0.5rem;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  color: #ffffff;
-  background: linear-gradient(
-    150deg,
-    rgba(40, 48, 78, 0.85) 0%,
-    rgba(13, 15, 26, 0.9) 100%
-  );
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    0 6px 22px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(6px) saturate(1.3);
-  -webkit-backdrop-filter: blur(6px) saturate(1.3);
-  transform: translateX(-50%);
-  transform-origin: bottom center;
-  animation:
-    globeTooltipPop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both,
-    globeTooltipFloat 3.4s ease-in-out 0.5s infinite;
-}
-
-/* Pointer arrow toward the selected dot */
-.globe-tooltip-bubble::after {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border: 6px solid transparent;
-  border-top-color: rgba(20, 23, 38, 0.9);
-}
-
-@keyframes globeTooltipPop {
-  0% {
-    opacity: 0;
-    transform: translateX(-50%) translateY(10px) scale(0.3);
-  }
-  60% {
-    opacity: 1;
-    transform: translateX(-50%) translateY(-3px) scale(1.07);
-  }
-  100% {
-    opacity: 1;
-    transform: translateX(-50%) translateY(0) scale(1);
-  }
-}
-
-/* Gentle hover-in-place after the pop settles */
-@keyframes globeTooltipFloat {
-  0%,
-  100% {
-    transform: translateX(-50%) translateY(0) scale(1);
-  }
-  50% {
-    transform: translateX(-50%) translateY(-4px) scale(1);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .globe-tooltip-bubble {
-    animation: none;
-  }
-}
-
 /* Allow the map mode dropdown to be interactive/visible within content-container */
 .map-mode-select {
   pointer-events: auto;
@@ -833,6 +750,17 @@ body:has(.album-page) {
       albumTitleItalicIn 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both,
       albumTitleItalicSway 2.8s ease-in-out 0.5s infinite;
   }
+}
+
+/* The active (italic) album title also fills with a horizontal blue gradient
+   (clipped to the text) so the current album reads as clearly selected */
+.album-list li span.album-title-active.album-title-italic,
+.globe-container.dark-mode .album-list li span.album-title-active.album-title-italic {
+  background: linear-gradient(90deg, #7db9ff 0%, #4f8bff 50%, #2f6bff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent !important;
 }
 
 @keyframes albumTitleItalicIn {

--- a/src/lib/globes/globe.tsx
+++ b/src/lib/globes/globe.tsx
@@ -300,14 +300,13 @@ function usePoints(albums: Array<Album>) {
     const locations = albums.filter(album => album.type === types.LOCATION);
     for (const album of locations) {
       // Prefer the bigger "album" dot when there is overlap.
-      pushUnique({ ...album, radius: 0.19, label: album.title });
+      pushUnique({ ...album, radius: 0.19 });
       for (const location of album.locations) {
         pushUnique({
           ...album,
           lat: location.lat,
           lng: location.lng,
-          radius: 0.135,
-          label: location.description || album.title
+          radius: 0.135
         });
       }
     }
@@ -320,23 +319,16 @@ function usePoints(albums: Array<Album>) {
   };
 }
 
-type ActiveMarker = { lat: number; lng: number; label: string };
-
 function useAlbumInteraction(
   globeEl: GlobeEl,
   setPointAltitude: React.Dispatch<React.SetStateAction<number>>,
   isPinnedRef?: React.MutableRefObject<boolean>
 ) {
   const [activeAlbumTitle, setActiveAlbumTitle] = useState<AlbumTitle>();
-  const [activeMarker, setActiveMarker] = useState<ActiveMarker | null>(null);
 
   const [enterTimeoutId, setEnterTimeoutId] = useState<NodeJS.Timeout>();
-  function handleMouseEnter({ lat, lng, title, type, label }: Album & { label?: string }) {
+  function handleMouseEnter({ lat, lng, title, type }: Album) {
     setActiveAlbumTitle(title);
-    if (type === types.LOCATION) {
-      // Anchor for the pop-up city tooltip: the exact point that was picked
-      setActiveMarker({ lat, lng, label: label ?? title });
-    }
 
     clearTimeout(enterTimeoutId);
 
@@ -373,7 +365,6 @@ function useAlbumInteraction(
     }
     setPointAltitude(BASE_POINT_ALTITUDE);
     setActiveAlbumTitle(undefined);
-    setActiveMarker(null);
 
     const defaultAltitude = isMobileDevice() ? 2.8 : 2;
     globeEl.current?.pointOfView(
@@ -399,7 +390,6 @@ function useAlbumInteraction(
 
   return {
     activeAlbumTitle,
-    activeMarker,
     handleMouseEnter,
     handleMouseLeave
   };
@@ -832,32 +822,9 @@ function Globe({ albums }: { albums: Array<Album> }) {
   const {
     handleMouseEnter,
     handleMouseLeave,
-    activeAlbumTitle,
-    activeMarker
+    activeAlbumTitle
   } = useAlbumInteraction(globeEl, setPointAltitude, isPinnedRef);
   const activeAlbum = albums.find(album => album.title === activeAlbumTitle);
-
-  // Pop-up city tooltip pinned to the selected point (CSS2D layer).
-  // A fresh data object per selection recreates the element, replaying the
-  // pop animation each time a new city is picked.
-  const tooltipData = React.useMemo(
-    () => (activeMarker ? [activeMarker] : []),
-    [activeMarker]
-  );
-  const tooltipElementCb = React.useCallback((d: object) => {
-    const root = document.createElement('div');
-    root.className = 'globe-tooltip';
-    root.style.pointerEvents = 'none';
-    const bubble = document.createElement('div');
-    bubble.className = 'globe-tooltip-bubble';
-    bubble.textContent = (d as ActiveMarker).label;
-    root.appendChild(bubble);
-    return root;
-  }, []);
-  const tooltipVisibilityCb = React.useCallback((el: HTMLElement, isVisible: boolean) => {
-    // Hide the tooltip while its anchor is on the far side of the globe
-    el.style.visibility = isVisible ? 'visible' : 'hidden';
-  }, []);
 
   // arcs animation
   const { arcs } = useArcs(albums);
@@ -1035,13 +1002,6 @@ function Globe({ albums }: { albums: Array<Album> }) {
         customLayerData={customLayerData}
         customThreeObject={customThreeObject}
         customThreeObjectUpdate={customThreeObjectUpdate}
-        htmlElementsData={tooltipData}
-        htmlLat="lat"
-        htmlLng="lng"
-        htmlAltitude={0.012}
-        htmlElement={tooltipElementCb}
-        htmlElementVisibilityModifier={tooltipVisibilityCb}
-        htmlTransitionDuration={0}
       />
 
       <section className={`content-container text-2xl ${isDesktopChrome ? 'fixed left-6 top-24 w-fit' : ''}`}>


### PR DESCRIPTION
- Remove the pop-up city tooltip that appeared over the selected point on
  the globe (the CSS2D html-elements layer): drop the tooltip CSS, the
  ActiveMarker state and element callbacks, the point `label` data, and the
  html* props on the globe. The animated gradient ocean and the mobile
  italic active-album treatment from the same commit are retained.
- Fill the active (italicized) album title with a horizontal blue gradient
  clipped to the text so the current album reads as clearly selected.
- Lengthen the on-load globe fade-in animation from 2.6s to 4.6s.